### PR TITLE
プロジェクト削除時にプロジェクトエンティティも削除するように修正

### DIFF
--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -450,13 +450,13 @@ func (s *SQLiteStore) DeleteProject(ctx context.Context, projectName string) err
 	queriesWithTx := s.queries.WithTx(tx)
 
 	// レコードを削除
-	err = queriesWithTx.DeleteProject(context.Background(), projectName)
+	err = queriesWithTx.DeleteProject(ctx, projectName)
 	if err != nil {
 		return fmt.Errorf("failed to delete project records: %w", err)
 	}
 
 	// プロジェクトエンティティを削除
-	err = queriesWithTx.DeleteProjectEntity(context.Background(), projectName)
+	err = queriesWithTx.DeleteProjectEntity(ctx, projectName)
 	if err != nil {
 		return fmt.Errorf("failed to delete project entity: %w", err)
 	}

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -448,9 +448,17 @@ func (s *SQLiteStore) DeleteProject(ctx context.Context, projectName string) err
 
 	// sqlcで生成されたクエリを使用（トランザクション内で）
 	queriesWithTx := s.queries.WithTx(tx)
+
+	// レコードを削除
 	err = queriesWithTx.DeleteProject(context.Background(), projectName)
 	if err != nil {
 		return fmt.Errorf("failed to delete project records: %w", err)
+	}
+
+	// プロジェクトエンティティを削除
+	err = queriesWithTx.DeleteProjectEntity(context.Background(), projectName)
+	if err != nil {
+		return fmt.Errorf("failed to delete project entity: %w", err)
 	}
 
 	// トランザクションのコミット

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -509,6 +509,12 @@ func TestDeleteProject(t *testing.T) {
 		t.Errorf("Expected 0 records for project1 after deletion, got %d", len(project1RecordsAfter))
 	}
 
+	// プロジェクト1のエンティティが削除されていることを確認
+	_, err = store.GetProject(context.Background(), project1)
+	if err == nil {
+		t.Errorf("Expected error when getting deleted project, got nil")
+	}
+
 	// プロジェクト2のレコードが残っていることを確認
 	project2Records, err := store.ListRecords(context.Background(), project2, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC), sortOrder)
 	if err != nil {
@@ -516,6 +522,12 @@ func TestDeleteProject(t *testing.T) {
 	}
 	if len(project2Records) != 2 {
 		t.Errorf("Expected 2 records for project2, got %d", len(project2Records))
+	}
+
+	// プロジェクト2のエンティティが残っていることを確認
+	_, err = store.GetProject(context.Background(), project2)
+	if err != nil {
+		t.Errorf("Expected project2 to still exist, got error: %v", err)
 	}
 
 	// 存在しないプロジェクトを削除しても問題ないことを確認


### PR DESCRIPTION
## 概要

プロジェクト削除API（`DELETE /v0/p/{project}`）を実行した際、プロジェクトに属するレコードのみが削除され、プロジェクトエンティティ自体が削除されない問題を修正しました。

## 問題点

- `DeleteProject`メソッドは`DeleteProject`クエリ（レコード削除）のみを呼び出していました
- プロジェクトエンティティを削除する`DeleteProjectEntity`クエリが呼び出されていませんでした
- その結果、プロジェクトのレコードは削除されるが、プロジェクト情報自体は残ってしまう状態でした

## 修正内容

### store/sqlite.go
- `DeleteProject`メソッドでレコード削除後に`DeleteProjectEntity`を呼び出すように修正
- トランザクション内で両方の削除処理を実行することで、データの整合性を保証

### store/sqlite_test.go  
- `TestDeleteProject`にプロジェクトエンティティが正しく削除されることを検証するテストケースを追加
- 削除されたプロジェクトが`GetProject`で取得できないことを確認
- 他のプロジェクトは影響を受けないことを確認

## テスト

- ✅ すべての既存テストが通過
- ✅ 新しいテストケースで修正内容を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)