### PR TITLE
Add pagination to project list API

### DIFF
--- a/db/querier.go
+++ b/db/querier.go
@@ -23,7 +23,7 @@ type Querier interface {
 	GetProjectTags(ctx context.Context, project string) ([]string, error)
 	GetRecord(ctx context.Context, id string) (Record, error)
 	GetRecordTags(ctx context.Context, recordID string) ([]string, error)
-	ListProjects(ctx context.Context) ([]Project, error)
+	ListProjects(ctx context.Context, arg ListProjectsParams) ([]Project, error)
 	// Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 	// Optimized query to avoid n+1 problem by using GROUP_CONCAT for tags
 	ListRecords(ctx context.Context, arg ListRecordsParams) ([]ListRecordsRow, error)

--- a/db/queries/records.sql
+++ b/db/queries/records.sql
@@ -88,7 +88,8 @@ DELETE FROM projects WHERE name = ?;
 -- name: ListProjects :many
 SELECT name, description, created_at, updated_at
 FROM projects
-ORDER BY updated_at DESC;
+ORDER BY updated_at DESC
+LIMIT ? OFFSET ?;
 
 -- name: GetProjectTags :many
 SELECT DISTINCT tag

--- a/db/records.sql.go
+++ b/db/records.sql.go
@@ -226,10 +226,16 @@ const listProjects = `-- name: ListProjects :many
 SELECT name, description, created_at, updated_at
 FROM projects
 ORDER BY updated_at DESC
+LIMIT ? OFFSET ?
 `
 
-func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
-	rows, err := q.db.QueryContext(ctx, listProjects)
+type ListProjectsParams struct {
+	Limit  int64 `db:"limit" json:"limit"`
+	Offset int64 `db:"offset" json:"offset"`
+}
+
+func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]Project, error) {
+	rows, err := q.db.QueryContext(ctx, listProjects, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stsysd/sougen/model"
 )
 
+// ListProjectsParams はプロジェクト一覧取得のパラメータです。
+type ListProjectsParams struct {
+	Pagination *model.Pagination
+}
+
 // RecordStore はレコードの保存と取得を行うインターフェースです。
 type RecordStore interface {
 	// CreateRecord は新しいレコードを作成します。
@@ -49,8 +54,8 @@ type ProjectStore interface {
 	UpdateProject(ctx context.Context, project *model.Project) error
 	// DeleteProjectEntity はプロジェクトエンティティのみを削除します（レコードは削除しません）。
 	DeleteProjectEntity(ctx context.Context, name string) error
-	// ListProjects はすべてのプロジェクトを取得します。
-	ListProjects(ctx context.Context) ([]*model.Project, error)
+	// ListProjects は指定されたパラメータに基づいてプロジェクトを取得します。
+	ListProjects(ctx context.Context, params *ListProjectsParams) ([]*model.Project, error)
 	// GetProjectTags は指定されたプロジェクトのタグ一覧を取得します。
 	GetProjectTags(ctx context.Context, projectName string) ([]string, error)
 }
@@ -618,9 +623,15 @@ func (s *SQLiteStore) DeleteProjectEntity(ctx context.Context, name string) erro
 }
 
 // ListProjects はすべてのプロジェクトを取得します。
-func (s *SQLiteStore) ListProjects(ctx context.Context) ([]*model.Project, error) {
+func (s *SQLiteStore) ListProjects(ctx context.Context, params *ListProjectsParams) ([]*model.Project, error) {
+	limit := int64(params.Pagination.Limit())
+	offset := int64(params.Pagination.Offset())
+
 	// sqlcで生成されたクエリを使用
-	dbProjects, err := s.queries.ListProjects(ctx)
+	dbProjects, err := s.queries.ListProjects(ctx, db.ListProjectsParams{
+		Limit:  limit,
+		Offset: offset,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list projects: %w", err)
 	}

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -1071,7 +1071,9 @@ func TestListProjects(t *testing.T) {
 	}
 
 	// プロジェクト一覧を取得
-	retrievedProjects, err := store.ListProjects(context.Background())
+	pagination, _ := model.NewPagination("100", "0")
+	params := &ListProjectsParams{Pagination: pagination}
+	retrievedProjects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)
 	}
@@ -1106,7 +1108,9 @@ func TestListEmptyProjects(t *testing.T) {
 	defer cleanup()
 
 	// プロジェクト一覧を取得（空のはず）
-	projects, err := store.ListProjects(context.Background())
+	pagination, _ := model.NewPagination("100", "0")
+	params := &ListProjectsParams{Pagination: pagination}
+	projects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)
 	}


### PR DESCRIPTION
## Summary
プロジェクト一覧取得API (GET /api/v0/p) にページネーション機能を追加しました。

## 変更内容
- SQLクエリにLIMIT/OFFSETを追加（DB-levelでの効率的なページネーション）
- `ListProjectsParams`構造体を追加し、Paginationパラメータを受け取るように変更
- クエリパラメータ `limit`, `offset` をサポート（デフォルト: limit=100, offset=0）
- 包括的なテストケースを追加（ページング動作、範囲外offset、デフォルト値など）

## テスト内容
- 最初のページ取得（limit=2, offset=0）
- 2ページ目取得（limit=2, offset=2）
- 最後のページ取得（limit=2, offset=4）
- 範囲外offsetの処理（空配列を返す）
- デフォルトパラメータの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)