### PR TITLE
Implement cursor-based pagination with Base64-encoded self-contained cursors

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -545,7 +545,7 @@ type ListRecordsParams struct {
 	ProjectName *model.ProjectName
 	DateRange   *model.DateRange
 	Tags        *model.Tags
-	Pagination  *model.CursorPagination
+	Pagination  *model.Pagination
 }
 
 // NewListRecordsParams creates parameters for record listing from HTTP request.
@@ -564,7 +564,7 @@ func NewListRecordsParams(r *http.Request) (*ListRecordsParams, error) {
 
 	tags := model.NewTags(query.Get("tags"))
 
-	pagination, err := model.NewCursorPagination(query.Get("limit"), query.Get("cursor"))
+	pagination, err := model.NewPagination(query.Get("limit"), query.Get("cursor"))
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +616,7 @@ func (s *Server) handleListRecords(w http.ResponseWriter, r *http.Request) {
 
 	// レコードの取得（limit+1 件取得して次ページの有無を判定）
 	originalLimit := params.Pagination.Limit()
-	storeParams.Pagination = model.NewCursorPaginationWithValues(originalLimit+1, params.Pagination.Cursor())
+	storeParams.Pagination = model.NewPaginationWithValues(originalLimit+1, params.Pagination.Cursor())
 
 	records, err := s.store.ListRecords(r.Context(), storeParams)
 	if err != nil {
@@ -704,14 +704,14 @@ func (s *Server) handleGetProject(w http.ResponseWriter, r *http.Request) {
 
 // ListProjectsParams はプロジェクト一覧取得のパラメータです。
 type ListProjectsParams struct {
-	Pagination *model.CursorPagination
+	Pagination *model.Pagination
 }
 
 // NewListProjectsParams はリクエストからプロジェクト一覧取得のパラメータを作成します。
 func NewListProjectsParams(r *http.Request) (*ListProjectsParams, error) {
 	query := r.URL.Query()
 
-	pagination, err := model.NewCursorPagination(query.Get("limit"), query.Get("cursor"))
+	pagination, err := model.NewPagination(query.Get("limit"), query.Get("cursor"))
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +745,7 @@ func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	// プロジェクトの取得（limit+1 件取得して次ページの有無を判定）
 	originalLimit := params.Pagination.Limit()
 	storeParams := &store.ListProjectsParams{
-		Pagination: model.NewCursorPaginationWithValues(originalLimit+1, params.Pagination.Cursor()),
+		Pagination: model.NewPaginationWithValues(originalLimit+1, params.Pagination.Cursor()),
 	}
 
 	projects, err := projectStore.ListProjects(r.Context(), storeParams)

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1196,7 +1196,7 @@ func TestDeleteProject(t *testing.T) {
 	}
 
 	// プロジェクトのレコードが削除されたことを確認
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	testRecords, err := mockStore.ListRecords(context.Background(), &store.ListRecordsParams{
 		Project:    "test",
 		From:       time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -2018,7 +2018,7 @@ func TestDeleteProjectEndpoint(t *testing.T) {
 	}
 
 	// レコードが削除されたことを確認
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	records, _ := mockStore.MockRecordStore.ListRecords(context.Background(), &store.ListRecordsParams{
 		Project:    "delete-test",
 		From:       time.Now().Add(-24 * time.Hour),

--- a/db/querier.go
+++ b/db/querier.go
@@ -23,15 +23,16 @@ type Querier interface {
 	GetProjectTags(ctx context.Context, project string) ([]string, error)
 	GetRecord(ctx context.Context, id string) (Record, error)
 	GetRecordTags(ctx context.Context, recordID string) ([]string, error)
+	// Cursor-based pagination: uses cursor_updated_at and cursor_name for pagination
 	ListProjects(ctx context.Context, arg ListProjectsParams) ([]Project, error)
 	// Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 	// Optimized query to avoid n+1 problem by using GROUP_CONCAT for tags
-	// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
+	// Cursor-based pagination: uses cursor_timestamp and cursor_id for pagination
 	ListRecords(ctx context.Context, arg ListRecordsParams) ([]ListRecordsRow, error)
 	// Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 	// Returns records that have all of the specified tags
 	// Optimized query to avoid n+1 problem by using GROUP_CONCAT for all tags
-	// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
+	// Cursor-based pagination: uses cursor_timestamp and cursor_id for pagination
 	ListRecordsWithTags(ctx context.Context, arg ListRecordsWithTagsParams) ([]ListRecordsWithTagsRow, error)
 	UpdateProject(ctx context.Context, arg UpdateProjectParams) (sql.Result, error)
 	UpdateRecord(ctx context.Context, arg UpdateRecordParams) (sql.Result, error)

--- a/db/querier.go
+++ b/db/querier.go
@@ -26,10 +26,12 @@ type Querier interface {
 	ListProjects(ctx context.Context, arg ListProjectsParams) ([]Project, error)
 	// Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 	// Optimized query to avoid n+1 problem by using GROUP_CONCAT for tags
+	// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
 	ListRecords(ctx context.Context, arg ListRecordsParams) ([]ListRecordsRow, error)
 	// Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 	// Returns records that have all of the specified tags
 	// Optimized query to avoid n+1 problem by using GROUP_CONCAT for all tags
+	// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
 	ListRecordsWithTags(ctx context.Context, arg ListRecordsWithTagsParams) ([]ListRecordsWithTagsRow, error)
 	UpdateProject(ctx context.Context, arg UpdateProjectParams) (sql.Result, error)
 	UpdateRecord(ctx context.Context, arg UpdateRecordParams) (sql.Result, error)

--- a/db/queries/records.sql
+++ b/db/queries/records.sql
@@ -92,10 +92,12 @@ WHERE name = ?;
 DELETE FROM projects WHERE name = ?;
 
 -- name: ListProjects :many
+-- Cursor-based pagination: uses cursor_updated_at and cursor_name for pagination
 SELECT name, description, created_at, updated_at
 FROM projects
-ORDER BY updated_at DESC
-LIMIT ? OFFSET ?;
+WHERE ? IS NULL OR updated_at < ? OR (updated_at = ? AND name > ?)
+ORDER BY updated_at DESC, name
+LIMIT ?;
 
 -- name: GetProjectTags :many
 SELECT DISTINCT tag

--- a/db/records.sql.go
+++ b/db/records.sql.go
@@ -272,17 +272,21 @@ SELECT
 FROM records r
 LEFT JOIN tags t ON r.id = t.record_id
 WHERE r.timestamp BETWEEN ? AND ? AND r.project = ?
+  AND (? IS NULL OR r.timestamp < ? OR (r.timestamp = ? AND r.id > ?))
 GROUP BY r.id, r.project, r.value, r.timestamp
-ORDER BY r.timestamp DESC
-LIMIT ? OFFSET ?
+ORDER BY r.timestamp DESC, r.id
+LIMIT ?
 `
 
 type ListRecordsParams struct {
-	Timestamp   string `db:"timestamp" json:"timestamp"`
-	Timestamp_2 string `db:"timestamp_2" json:"timestamp_2"`
-	Project     string `db:"project" json:"project"`
-	Limit       int64  `db:"limit" json:"limit"`
-	Offset      int64  `db:"offset" json:"offset"`
+	Timestamp   string      `db:"timestamp" json:"timestamp"`
+	Timestamp_2 string      `db:"timestamp_2" json:"timestamp_2"`
+	Project     string      `db:"project" json:"project"`
+	Column4     interface{} `db:"column_4" json:"column_4"`
+	Timestamp_3 string      `db:"timestamp_3" json:"timestamp_3"`
+	Timestamp_4 string      `db:"timestamp_4" json:"timestamp_4"`
+	ID          string      `db:"id" json:"id"`
+	Limit       int64       `db:"limit" json:"limit"`
 }
 
 type ListRecordsRow struct {
@@ -295,13 +299,17 @@ type ListRecordsRow struct {
 
 // Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 // Optimized query to avoid n+1 problem by using GROUP_CONCAT for tags
+// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
 func (q *Queries) ListRecords(ctx context.Context, arg ListRecordsParams) ([]ListRecordsRow, error) {
 	rows, err := q.db.QueryContext(ctx, listRecords,
 		arg.Timestamp,
 		arg.Timestamp_2,
 		arg.Project,
+		arg.Column4,
+		arg.Timestamp_3,
+		arg.Timestamp_4,
+		arg.ID,
 		arg.Limit,
-		arg.Offset,
 	)
 	if err != nil {
 		return nil, err
@@ -341,20 +349,24 @@ FROM records r
 INNER JOIN tags t ON r.id = t.record_id
 WHERE r.timestamp BETWEEN ? AND ? AND r.project = ?
   AND t.tag IN (/*SLICE:tags*/?)
+  AND (? IS NULL OR r.timestamp < ? OR (r.timestamp = ? AND r.id > ?))
 GROUP BY r.id, r.project, r.value, r.timestamp
 HAVING COUNT(DISTINCT t.tag) = CAST(? AS INTEGER)
-ORDER BY r.timestamp DESC
-LIMIT ? OFFSET ?
+ORDER BY r.timestamp DESC, r.id
+LIMIT ?
 `
 
 type ListRecordsWithTagsParams struct {
-	Timestamp   string   `db:"timestamp" json:"timestamp"`
-	Timestamp_2 string   `db:"timestamp_2" json:"timestamp_2"`
-	Project     string   `db:"project" json:"project"`
-	Tags        []string `db:"tags" json:"tags"`
-	Column5     int64    `db:"column_5" json:"column_5"`
-	Limit       int64    `db:"limit" json:"limit"`
-	Offset      int64    `db:"offset" json:"offset"`
+	Timestamp   string      `db:"timestamp" json:"timestamp"`
+	Timestamp_2 string      `db:"timestamp_2" json:"timestamp_2"`
+	Project     string      `db:"project" json:"project"`
+	Tags        []string    `db:"tags" json:"tags"`
+	Column5     interface{} `db:"column_5" json:"column_5"`
+	Timestamp_3 string      `db:"timestamp_3" json:"timestamp_3"`
+	Timestamp_4 string      `db:"timestamp_4" json:"timestamp_4"`
+	ID          string      `db:"id" json:"id"`
+	Column9     int64       `db:"column_9" json:"column_9"`
+	Limit       int64       `db:"limit" json:"limit"`
 }
 
 type ListRecordsWithTagsRow struct {
@@ -368,6 +380,7 @@ type ListRecordsWithTagsRow struct {
 // Note: BETWEEN clause must come first due to sqlc bug with SQLite parameter handling
 // Returns records that have all of the specified tags
 // Optimized query to avoid n+1 problem by using GROUP_CONCAT for all tags
+// Cursor-based pagination: uses anchor_timestamp and anchor_id for pagination
 func (q *Queries) ListRecordsWithTags(ctx context.Context, arg ListRecordsWithTagsParams) ([]ListRecordsWithTagsRow, error) {
 	query := listRecordsWithTags
 	var queryParams []interface{}
@@ -383,8 +396,11 @@ func (q *Queries) ListRecordsWithTags(ctx context.Context, arg ListRecordsWithTa
 		query = strings.Replace(query, "/*SLICE:tags*/?", "NULL", 1)
 	}
 	queryParams = append(queryParams, arg.Column5)
+	queryParams = append(queryParams, arg.Timestamp_3)
+	queryParams = append(queryParams, arg.Timestamp_4)
+	queryParams = append(queryParams, arg.ID)
+	queryParams = append(queryParams, arg.Column9)
 	queryParams = append(queryParams, arg.Limit)
-	queryParams = append(queryParams, arg.Offset)
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/db/schema/005_add_timestamp_id_index.sql
+++ b/db/schema/005_add_timestamp_id_index.sql
@@ -1,0 +1,4 @@
+-- Add composite index for cursor-based pagination
+-- This index supports efficient queries with ORDER BY timestamp DESC, id
+CREATE INDEX idx_records_project_timestamp_id
+ON records(project, timestamp DESC, id);

--- a/db/schema/006_add_projects_updated_at_name_index.sql
+++ b/db/schema/006_add_projects_updated_at_name_index.sql
@@ -1,0 +1,4 @@
+-- Add composite index for cursor-based pagination on projects
+-- This index supports efficient queries with ORDER BY updated_at DESC, name
+CREATE INDEX idx_projects_updated_at_name
+ON projects(updated_at DESC, name);

--- a/model/value_objects.go
+++ b/model/value_objects.go
@@ -233,6 +233,61 @@ type Pagination struct {
 	offset int
 }
 
+// CursorPagination represents cursor-based pagination parameters for records.
+type CursorPagination struct {
+	limit  int
+	cursor *uuid.UUID // Cursor for pagination (nil means start from the beginning)
+}
+
+// NewCursorPagination creates a new cursor-based pagination value object.
+func NewCursorPagination(limitStr, cursorStr string) (*CursorPagination, error) {
+	limit := 100 // Default value
+
+	// Process limit parameter
+	if limitStr != "" {
+		parsedLimit, err := parseInt(limitStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit parameter: must be a positive integer")
+		}
+		if parsedLimit <= 0 {
+			return nil, fmt.Errorf("limit must be greater than 0")
+		}
+		if parsedLimit > 1000 { // Set upper limit
+			parsedLimit = 1000
+		}
+		limit = parsedLimit
+	}
+
+	// Process cursor parameter
+	var cursor *uuid.UUID
+	if cursorStr != "" {
+		parsedCursor, err := uuid.Parse(cursorStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor parameter: must be a valid UUID")
+		}
+		cursor = &parsedCursor
+	}
+
+	return &CursorPagination{limit: limit, cursor: cursor}, nil
+}
+
+// NewCursorPaginationWithValues creates a CursorPagination directly from values (for internal use).
+// No validation is performed on the values.
+func NewCursorPaginationWithValues(limit int, cursor *uuid.UUID) *CursorPagination {
+	return &CursorPagination{limit: limit, cursor: cursor}
+}
+
+// Limit returns the limit value.
+func (p *CursorPagination) Limit() int {
+	return p.limit
+}
+
+// Cursor returns the cursor UUID for cursor-based pagination.
+// Returns nil if no cursor is set (i.e., start from the beginning).
+func (p *CursorPagination) Cursor() *uuid.UUID {
+	return p.cursor
+}
+
 // NewPagination creates a new pagination value object.
 func NewPagination(limitStr, offsetStr string) (*Pagination, error) {
 	limit := 100 // Default value

--- a/model/value_objects.go
+++ b/model/value_objects.go
@@ -227,20 +227,14 @@ func (v *Value) Int() int {
 	return v.value
 }
 
-// Pagination represents pagination parameters value object.
+// Pagination represents cursor-based pagination parameters for records and projects.
 type Pagination struct {
-	limit  int
-	offset int
-}
-
-// CursorPagination represents cursor-based pagination parameters for records and projects.
-type CursorPagination struct {
 	limit  int
 	cursor *string // Cursor for pagination (nil means start from the beginning)
 }
 
-// NewCursorPagination creates a new cursor-based pagination value object.
-func NewCursorPagination(limitStr, cursorStr string) (*CursorPagination, error) {
+// NewPagination creates a new cursor-based pagination value object.
+func NewPagination(limitStr, cursorStr string) (*Pagination, error) {
 	limit := 100 // Default value
 
 	// Process limit parameter
@@ -264,65 +258,13 @@ func NewCursorPagination(limitStr, cursorStr string) (*CursorPagination, error) 
 		cursor = &cursorStr
 	}
 
-	return &CursorPagination{limit: limit, cursor: cursor}, nil
+	return &Pagination{limit: limit, cursor: cursor}, nil
 }
 
-// NewCursorPaginationWithValues creates a CursorPagination directly from values (for internal use).
+// NewPaginationWithValues creates a Pagination directly from values (for internal use).
 // No validation is performed on the values.
-func NewCursorPaginationWithValues(limit int, cursor *string) *CursorPagination {
-	return &CursorPagination{limit: limit, cursor: cursor}
-}
-
-// Limit returns the limit value.
-func (p *CursorPagination) Limit() int {
-	return p.limit
-}
-
-// Cursor returns the cursor string for cursor-based pagination.
-// Returns nil if no cursor is set (i.e., start from the beginning).
-func (p *CursorPagination) Cursor() *string {
-	return p.cursor
-}
-
-// NewPagination creates a new pagination value object.
-func NewPagination(limitStr, offsetStr string) (*Pagination, error) {
-	limit := 100 // Default value
-	offset := 0  // Default value
-
-	// Process limit parameter
-	if limitStr != "" {
-		parsedLimit, err := parseInt(limitStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid limit parameter: must be a positive integer")
-		}
-		if parsedLimit <= 0 {
-			return nil, fmt.Errorf("limit must be greater than 0")
-		}
-		if parsedLimit > 1000 { // Set upper limit
-			parsedLimit = 1000
-		}
-		limit = parsedLimit
-	}
-
-	// Process offset parameter
-	if offsetStr != "" {
-		parsedOffset, err := parseInt(offsetStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid offset parameter: must be a non-negative integer")
-		}
-		if parsedOffset < 0 {
-			return nil, fmt.Errorf("offset must be non-negative")
-		}
-		offset = parsedOffset
-	}
-
-	return &Pagination{limit: limit, offset: offset}, nil
-}
-
-// NewPaginationWithValues creates a Pagination directly from integer values (for internal use).
-// No validation is performed on the values.
-func NewPaginationWithValues(limit, offset int) *Pagination {
-	return &Pagination{limit: limit, offset: offset}
+func NewPaginationWithValues(limit int, cursor *string) *Pagination {
+	return &Pagination{limit: limit, cursor: cursor}
 }
 
 // Limit returns the limit value.
@@ -330,9 +272,10 @@ func (p *Pagination) Limit() int {
 	return p.limit
 }
 
-// Offset returns the offset value.
-func (p *Pagination) Offset() int {
-	return p.offset
+// Cursor returns the cursor string for cursor-based pagination.
+// Returns nil if no cursor is set (i.e., start from the beginning).
+func (p *Pagination) Cursor() *string {
+	return p.cursor
 }
 
 // parseInt converts a string to an integer and handles errors.

--- a/model/value_objects.go
+++ b/model/value_objects.go
@@ -233,10 +233,10 @@ type Pagination struct {
 	offset int
 }
 
-// CursorPagination represents cursor-based pagination parameters for records.
+// CursorPagination represents cursor-based pagination parameters for records and projects.
 type CursorPagination struct {
 	limit  int
-	cursor *uuid.UUID // Cursor for pagination (nil means start from the beginning)
+	cursor *string // Cursor for pagination (nil means start from the beginning)
 }
 
 // NewCursorPagination creates a new cursor-based pagination value object.
@@ -259,13 +259,9 @@ func NewCursorPagination(limitStr, cursorStr string) (*CursorPagination, error) 
 	}
 
 	// Process cursor parameter
-	var cursor *uuid.UUID
+	var cursor *string
 	if cursorStr != "" {
-		parsedCursor, err := uuid.Parse(cursorStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid cursor parameter: must be a valid UUID")
-		}
-		cursor = &parsedCursor
+		cursor = &cursorStr
 	}
 
 	return &CursorPagination{limit: limit, cursor: cursor}, nil
@@ -273,7 +269,7 @@ func NewCursorPagination(limitStr, cursorStr string) (*CursorPagination, error) 
 
 // NewCursorPaginationWithValues creates a CursorPagination directly from values (for internal use).
 // No validation is performed on the values.
-func NewCursorPaginationWithValues(limit int, cursor *uuid.UUID) *CursorPagination {
+func NewCursorPaginationWithValues(limit int, cursor *string) *CursorPagination {
 	return &CursorPagination{limit: limit, cursor: cursor}
 }
 
@@ -282,9 +278,9 @@ func (p *CursorPagination) Limit() int {
 	return p.limit
 }
 
-// Cursor returns the cursor UUID for cursor-based pagination.
+// Cursor returns the cursor string for cursor-based pagination.
 // Returns nil if no cursor is set (i.e., start from the beginning).
-func (p *CursorPagination) Cursor() *uuid.UUID {
+func (p *CursorPagination) Cursor() *string {
 	return p.cursor
 }
 

--- a/model/value_objects.go
+++ b/model/value_objects.go
@@ -2,6 +2,8 @@
 package model
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -225,6 +227,102 @@ func NewValue(val *int) (*Value, error) {
 // Int returns the integer value.
 func (v *Value) Int() int {
 	return v.value
+}
+
+// RecordFilterParams represents filter parameters for record queries.
+type RecordFilterParams struct {
+	Project string   `json:"project"`        // Project name for filtering
+	From    string   `json:"from"`           // Start date for filtering (RFC3339)
+	To      string   `json:"to"`             // End date for filtering (RFC3339)
+	Tags    []string `json:"tags,omitempty"` // Tags for filtering
+}
+
+// RecordCursor represents a keyset cursor for record pagination.
+// It embeds RecordFilterParams to guarantee all filter parameters are included.
+type RecordCursor struct {
+	RecordFilterParams        // Embedded filter parameters
+	Timestamp          string `json:"timestamp"` // RFC3339 formatted timestamp of the last record
+	ID                 string `json:"id"`        // UUID of the last record
+}
+
+// ProjectCursor represents a keyset cursor for project pagination.
+type ProjectCursor struct {
+	UpdatedAt string `json:"updated_at"` // RFC3339 formatted updated_at of the last project
+	Name      string `json:"name"`       // Name of the last project
+}
+
+// EncodeRecordCursor encodes a record cursor to a Base64 string.
+func EncodeRecordCursor(timestamp time.Time, id, project string, from, to time.Time, tags []string) string {
+	// Convert zero-value times to empty strings
+	fromStr := ""
+	if !from.IsZero() {
+		fromStr = from.Format(time.RFC3339)
+	}
+	toStr := ""
+	if !to.IsZero() {
+		toStr = to.Format(time.RFC3339)
+	}
+
+	cursor := RecordCursor{
+		RecordFilterParams: RecordFilterParams{
+			Project: project,
+			From:    fromStr,
+			To:      toStr,
+			Tags:    tags,
+		},
+		Timestamp: timestamp.Format(time.RFC3339),
+		ID:        id,
+	}
+	jsonData, _ := json.Marshal(cursor)
+	return base64.URLEncoding.EncodeToString(jsonData)
+}
+
+// DecodeRecordCursor decodes a Base64 encoded record cursor string.
+func DecodeRecordCursor(encoded string) (*RecordCursor, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor: failed to decode base64: %w", err)
+	}
+
+	var cursor RecordCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return nil, fmt.Errorf("invalid cursor: failed to unmarshal json: %w", err)
+	}
+
+	return &cursor, nil
+}
+
+// EncodeProjectCursor encodes a project cursor to a Base64 string.
+func EncodeProjectCursor(updatedAt time.Time, name string) string {
+	cursor := ProjectCursor{
+		UpdatedAt: updatedAt.Format(time.RFC3339),
+		Name:      name,
+	}
+	jsonData, _ := json.Marshal(cursor)
+	return base64.URLEncoding.EncodeToString(jsonData)
+}
+
+// DecodeProjectCursor decodes a Base64 encoded project cursor string.
+func DecodeProjectCursor(encoded string) (*ProjectCursor, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor: failed to decode base64: %w", err)
+	}
+
+	var cursor ProjectCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return nil, fmt.Errorf("invalid cursor: failed to unmarshal json: %w", err)
+	}
+
+	return &cursor, nil
 }
 
 // Pagination represents cursor-based pagination parameters for records and projects.

--- a/model/value_objects_test.go
+++ b/model/value_objects_test.go
@@ -1,0 +1,131 @@
+package model
+
+import (
+	"testing"
+)
+
+// TestNewPagination tests the NewPagination function
+func TestNewPagination(t *testing.T) {
+	tests := []struct {
+		name        string
+		limitStr    string
+		cursorStr   string
+		expectError bool
+		expectedLimit int
+		description string
+	}{
+		{
+			name:          "Valid limit and cursor",
+			limitStr:      "50",
+			cursorStr:     "test-cursor",
+			expectError:   false,
+			expectedLimit: 50,
+			description:   "正常なlimitとcursorで成功すること",
+		},
+		{
+			name:          "Default limit with empty strings",
+			limitStr:      "",
+			cursorStr:     "",
+			expectError:   false,
+			expectedLimit: 100,
+			description:   "空文字列の場合、デフォルトのlimit=100が設定されること",
+		},
+		{
+			name:          "Valid limit without cursor",
+			limitStr:      "25",
+			cursorStr:     "",
+			expectError:   false,
+			expectedLimit: 25,
+			description:   "cursorなしでも正常に動作すること",
+		},
+		{
+			name:          "Limit exceeds maximum",
+			limitStr:      "2000",
+			cursorStr:     "",
+			expectError:   false,
+			expectedLimit: 1000,
+			description:   "limitが1000を超える場合、1000に制限されること",
+		},
+		{
+			name:          "Invalid limit (non-numeric)",
+			limitStr:      "abc",
+			cursorStr:     "",
+			expectError:   true,
+			expectedLimit: 0,
+			description:   "limitが数値でない場合、エラーになること",
+		},
+		{
+			name:          "Invalid limit (negative)",
+			limitStr:      "-10",
+			cursorStr:     "",
+			expectError:   true,
+			expectedLimit: 0,
+			description:   "limitが負の数の場合、エラーになること",
+		},
+		{
+			name:          "Invalid limit (zero)",
+			limitStr:      "0",
+			cursorStr:     "",
+			expectError:   true,
+			expectedLimit: 0,
+			description:   "limitが0の場合、エラーになること",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pagination, err := NewPagination(tt.limitStr, tt.cursorStr)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("%s: expected error but got nil", tt.description)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", tt.description, err)
+				return
+			}
+
+			if pagination.Limit() != tt.expectedLimit {
+				t.Errorf("%s: expected limit %d, got %d", tt.description, tt.expectedLimit, pagination.Limit())
+			}
+
+			// cursorのチェック
+			if tt.cursorStr == "" {
+				if pagination.Cursor() != nil {
+					t.Errorf("%s: expected nil cursor, got %v", tt.description, pagination.Cursor())
+				}
+			} else {
+				if pagination.Cursor() == nil {
+					t.Errorf("%s: expected cursor %s, got nil", tt.description, tt.cursorStr)
+				} else if *pagination.Cursor() != tt.cursorStr {
+					t.Errorf("%s: expected cursor %s, got %s", tt.description, tt.cursorStr, *pagination.Cursor())
+				}
+			}
+		})
+	}
+}
+
+// TestNewPaginationWithValues tests the NewPaginationWithValues function
+func TestNewPaginationWithValues(t *testing.T) {
+	cursor := "test-cursor"
+	pagination := NewPaginationWithValues(50, &cursor)
+
+	if pagination.Limit() != 50 {
+		t.Errorf("Expected limit 50, got %d", pagination.Limit())
+	}
+
+	if pagination.Cursor() == nil {
+		t.Error("Expected cursor to be set, got nil")
+	} else if *pagination.Cursor() != cursor {
+		t.Errorf("Expected cursor %s, got %s", cursor, *pagination.Cursor())
+	}
+
+	// nil cursorのテスト
+	paginationNilCursor := NewPaginationWithValues(100, nil)
+	if paginationNilCursor.Cursor() != nil {
+		t.Errorf("Expected nil cursor, got %v", paginationNilCursor.Cursor())
+	}
+}

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -324,7 +324,7 @@ func (s *SQLiteStore) ListRecords(ctx context.Context, params *ListRecordsParams
 		// カーソルが指定されている場合、パラメータから直接取得
 		cursorID = *params.CursorID
 		cursorTimestamp = params.CursorTimestamp.Format(time.RFC3339)
-		cursorColumn = nil // NULL ではなく、有効な値として扱う
+		cursorColumn = 1 // 非NULL値を設定してSQLの "? IS NULL" をFALSEにする
 	} else {
 		// カーソルが指定されていない場合は NULL
 		cursorColumn = nil
@@ -688,7 +688,7 @@ func (s *SQLiteStore) ListProjects(ctx context.Context, params *ListProjectsPara
 		// カーソルが指定されている場合、パラメータから直接取得
 		cursorName = *params.CursorName
 		cursorUpdatedAt = params.CursorUpdatedAt.Format(time.RFC3339)
-		cursorColumn = nil // NULL ではなく、有効な値として扱う
+		cursorColumn = 1 // 非NULL値を設定してSQLの "? IS NULL" をFALSEにする
 	} else {
 		// カーソルが指定されていない場合は NULL
 		cursorColumn = nil

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -319,7 +319,7 @@ func (s *SQLiteStore) ListRecords(ctx context.Context, params *ListRecordsParams
 	// カーソルベースのページネーションパラメータ
 	var cursorID string
 	var cursorTimestamp string
-	var cursorColumn interface{}
+	var cursorColumn any
 	if params.CursorTimestamp != nil && params.CursorID != nil {
 		// カーソルが指定されている場合、パラメータから直接取得
 		cursorID = *params.CursorID
@@ -688,7 +688,7 @@ func (s *SQLiteStore) ListProjects(ctx context.Context, params *ListProjectsPara
 	// カーソルベースのページネーションパラメータ
 	var cursorName string
 	var cursorUpdatedAt string
-	var cursorColumn interface{}
+	var cursorColumn any
 	if params.CursorUpdatedAt != nil && params.CursorName != nil {
 		// カーソルが指定されている場合、パラメータから直接取得
 		cursorName = *params.CursorName

--- a/store/sqlite.go
+++ b/store/sqlite.go
@@ -20,7 +20,7 @@ import (
 
 // ListProjectsParams はプロジェクト一覧取得のパラメータです。
 type ListProjectsParams struct {
-	Pagination *model.CursorPagination
+	Pagination *model.Pagination
 }
 
 // ListRecordsParams はレコード一覧取得のパラメータです。
@@ -28,7 +28,7 @@ type ListRecordsParams struct {
 	Project    string
 	From       time.Time
 	To         time.Time
-	Pagination *model.CursorPagination
+	Pagination *model.Pagination
 	Tags       []string
 }
 
@@ -427,7 +427,7 @@ func (s *SQLiteStore) ListAllRecords(ctx context.Context, params *ListAllRecords
 		var cursor *string
 
 		for {
-			pagination := model.NewCursorPaginationWithValues(pageSize, cursor)
+			pagination := model.NewPaginationWithValues(pageSize, cursor)
 
 			listParams := &ListRecordsParams{
 				Project:    params.Project,

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -280,7 +280,7 @@ func TestListRecords(t *testing.T) {
 	// テストの実行
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pagination, _ := model.NewPagination("100", "0")
+			pagination, _ := model.NewCursorPagination("100", "")
 			result, err := store.ListRecords(context.Background(), &ListRecordsParams{
 				Project:    project,
 				From:       tc.from,
@@ -371,7 +371,7 @@ func TestDeleteProject(t *testing.T) {
 	}
 
 	// プロジェクト1のレコード数を確認
-	pagination, _ := model.NewPagination("100", "0")
+	pagination, _ := model.NewCursorPagination("100", "")
 	project1Records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project1,
 		From:       time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -543,7 +543,7 @@ func TestListRecordsWithTags(t *testing.T) {
 			toTime := baseTime.Add(5 * time.Hour)
 
 			// タグフィルタでレコードを取得
-			pagination, _ := model.NewPagination("100", "0")
+			pagination, _ := model.NewCursorPagination("100", "")
 			records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 				Project:    project,
 				From:       fromTime,
@@ -616,7 +616,7 @@ func TestListRecordsWithTagsEmptyResult(t *testing.T) {
 	// 存在しないタグでフィルタ
 	fromTime := baseTime.Add(-1 * time.Hour)
 	toTime := baseTime.Add(1 * time.Hour)
-	pagination, _ := model.NewPagination("100", "0")
+	pagination, _ := model.NewCursorPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project,
 		From:       fromTime,
@@ -666,7 +666,7 @@ func TestListRecordsDateRange(t *testing.T) {
 	// 最初の2日分のみを取得
 	fromTime := baseTime.Add(-1 * time.Hour)
 	toTime := baseTime.Add(25 * time.Hour)
-	pagination, _ := model.NewPagination("100", "0")
+	pagination, _ := model.NewCursorPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project,
 		From:       fromTime,
@@ -893,8 +893,7 @@ func TestListProjects(t *testing.T) {
 	}
 
 	// プロジェクト一覧を取得
-	pagination, _ := model.NewPagination("100", "0")
-	params := &ListProjectsParams{Pagination: pagination}
+	params := &ListProjectsParams{Limit: 100, Offset: 0}
 	retrievedProjects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)
@@ -930,8 +929,7 @@ func TestListEmptyProjects(t *testing.T) {
 	defer cleanup()
 
 	// プロジェクト一覧を取得（空のはず）
-	pagination, _ := model.NewPagination("100", "0")
-	params := &ListProjectsParams{Pagination: pagination}
+	params := &ListProjectsParams{Limit: 100, Offset: 0}
 	projects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)
@@ -1018,7 +1016,7 @@ func TestProjectDeletionWithOrphanedRecords(t *testing.T) {
 	}
 
 	// 外部キー制約がないため、関連するレコードは残っている
-	pagination, _ := model.NewPagination("100", "0")
+	pagination, _ := model.NewCursorPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    "test-project",
 		From:       timestamp.Add(-1 * time.Hour),

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -893,7 +893,8 @@ func TestListProjects(t *testing.T) {
 	}
 
 	// プロジェクト一覧を取得
-	params := &ListProjectsParams{Limit: 100, Offset: 0}
+	pagination, _ := model.NewCursorPagination("100", "")
+	params := &ListProjectsParams{Pagination: pagination}
 	retrievedProjects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)
@@ -929,7 +930,8 @@ func TestListEmptyProjects(t *testing.T) {
 	defer cleanup()
 
 	// プロジェクト一覧を取得（空のはず）
-	params := &ListProjectsParams{Limit: 100, Offset: 0}
+	pagination, _ := model.NewCursorPagination("100", "")
+	params := &ListProjectsParams{Pagination: pagination}
 	projects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
 		t.Fatalf("Failed to list projects: %v", err)

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -280,7 +280,7 @@ func TestListRecords(t *testing.T) {
 	// テストの実行
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pagination, _ := model.NewCursorPagination("100", "")
+			pagination, _ := model.NewPagination("100", "")
 			result, err := store.ListRecords(context.Background(), &ListRecordsParams{
 				Project:    project,
 				From:       tc.from,
@@ -371,7 +371,7 @@ func TestDeleteProject(t *testing.T) {
 	}
 
 	// プロジェクト1のレコード数を確認
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	project1Records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project1,
 		From:       time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -543,7 +543,7 @@ func TestListRecordsWithTags(t *testing.T) {
 			toTime := baseTime.Add(5 * time.Hour)
 
 			// タグフィルタでレコードを取得
-			pagination, _ := model.NewCursorPagination("100", "")
+			pagination, _ := model.NewPagination("100", "")
 			records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 				Project:    project,
 				From:       fromTime,
@@ -616,7 +616,7 @@ func TestListRecordsWithTagsEmptyResult(t *testing.T) {
 	// 存在しないタグでフィルタ
 	fromTime := baseTime.Add(-1 * time.Hour)
 	toTime := baseTime.Add(1 * time.Hour)
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project,
 		From:       fromTime,
@@ -666,7 +666,7 @@ func TestListRecordsDateRange(t *testing.T) {
 	// 最初の2日分のみを取得
 	fromTime := baseTime.Add(-1 * time.Hour)
 	toTime := baseTime.Add(25 * time.Hour)
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    project,
 		From:       fromTime,
@@ -893,7 +893,7 @@ func TestListProjects(t *testing.T) {
 	}
 
 	// プロジェクト一覧を取得
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	params := &ListProjectsParams{Pagination: pagination}
 	retrievedProjects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
@@ -930,7 +930,7 @@ func TestListEmptyProjects(t *testing.T) {
 	defer cleanup()
 
 	// プロジェクト一覧を取得（空のはず）
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	params := &ListProjectsParams{Pagination: pagination}
 	projects, err := store.ListProjects(context.Background(), params)
 	if err != nil {
@@ -1018,7 +1018,7 @@ func TestProjectDeletionWithOrphanedRecords(t *testing.T) {
 	}
 
 	// 外部キー制約がないため、関連するレコードは残っている
-	pagination, _ := model.NewCursorPagination("100", "")
+	pagination, _ := model.NewPagination("100", "")
 	records, err := store.ListRecords(context.Background(), &ListRecordsParams{
 		Project:    "test-project",
 		From:       timestamp.Add(-1 * time.Hour),


### PR DESCRIPTION
## Summary

このPRは、RecordsとProjectsのリスト取得APIにカーソルベースのページネーションを実装し、さらにBase64エンコードされた自己完結型カーソルに移行します。

## Changes

### Phase 1: Initial cursor-based pagination implementation
- ✅ Recordsリスト取得にカーソルベースのページネーションを実装
- ✅ Projectsリスト取得にもカーソルベースのページネーションを拡張
- ✅ `CursorPagination`を`Pagination`にリネームして一般化
- ✅ 包括的なページネーションテストを追加

### Phase 2: Migration to Base64-encoded keyset pagination (このPR)
- ✅ Base64エンコードされたJSONカーソルに移行
- ✅ 自己完結型カーソル（全フィルタパラメータを含む）
- ✅ Keyset pagination（timestamp + ID）で安定性向上
- ✅ カーソルレコードが削除されても動作する

## Technical Implementation

### Model Layer
- `RecordFilterParams`構造体: フィルタパラメータ（project, from, to, tags）
- `RecordCursor`構造体: 構造体埋め込みで型安全性を保証
- `ProjectCursor`構造体: プロジェクトページネーション用
- Base64エンコード/デコード関数の実装

### API Layer
- `NewListRecordsParams`: カーソルから全パラメータを復元
- `buildRecordCursorPath`: 全パラメータを含むカーソル生成
- `buildProjectCursorPath`: プロジェクト用カーソル生成
- カーソルのデコードと位置情報の抽出

### Store Layer
- `CursorTimestamp`/`CursorID`フィールドを追加（Records）
- `CursorUpdatedAt`/`CursorName`フィールドを追加（Projects）
- `GetRecord`/`GetProject`呼び出しを削除
- パラメータから直接カーソル情報を使用

### Tests
- Base64エンコード形式に対応したテスト更新
- MockStoreの実装を新しいパラメータ構造に対応
- 不正なカーソル形式のテスト追加

## Benefits

1. **削除に強い**: カーソルレコードが削除されてもページネーションが機能
2. **シンプルなURL**: Next URLは`?cursor=xxx&limit=n`のみ
3. **自己完結型**: クライアントがフィルタパラメータを管理不要
4. **型安全**: 構造体埋め込みでコンパイル時にフィールド保証
5. **業界標準**: GraphQL Relay仕様に準拠

## Test Results

```
✅ All tests passing
- api package: PASS
- model package: PASS
- store package: PASS
```

## API Examples

### Before (ID-based cursor)
```
GET /api/v0/p/exercise/r?from=2024-01-01&to=2024-12-31&tags=work&limit=10
→ Next: /api/v0/p/exercise/r?cursor=uuid-here&limit=10
   ❌ 問題: from/to/tagsが欠落、cursorレコード削除でエラー
```

### After (Base64 keyset cursor)
```
GET /api/v0/p/exercise/r?from=2024-01-01&to=2024-12-31&tags=work&limit=10
→ Next: /api/v0/p/exercise/r?cursor=eyJwcm9qZWN0Ijo...&limit=10
   ✅ カーソルに全パラメータ含む、削除に強い
```

## Migration Notes

- 既存のAPIエンドポイントは変更なし
- カーソル形式が変更されたが、後方互換性は不要（新機能）
- 不正なカーソル形式は400 BadRequestを返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)