### PR TITLE
Refactor: DB package structure and add tag order preservation

### DIFF
--- a/db/migration.go
+++ b/db/migration.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -8,11 +8,11 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-//go:embed db/schema/*.sql
+//go:embed schema/*.sql
 var embedMigrations embed.FS
 
-// runMigrations はデータベースに対してマイグレーションを実行します。
-func runMigrations(conn *sql.DB) error {
+// Migrate はデータベースに対してマイグレーションを実行します。
+func Migrate(conn *sql.DB) error {
 	// 外部キー制約を有効化
 	_, err := conn.Exec(`PRAGMA foreign_keys = ON;`)
 	if err != nil {
@@ -28,7 +28,7 @@ func runMigrations(conn *sql.DB) error {
 	}
 
 	// マイグレーションを実行
-	if err := goose.Up(conn, "db/schema"); err != nil {
+	if err := goose.Up(conn, "schema"); err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 

--- a/db/sqlc/db.go
+++ b/db/sqlc/db.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.29.0
 
-package db
+package sqlc
 
 import (
 	"context"

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.29.0
 
-package db
+package sqlc
 
 type Project struct {
 	ID          int64  `db:"id" json:"id"`

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.29.0
 
-package db
+package sqlc
 
 import (
 	"context"

--- a/db/sqlc/records.sql.go
+++ b/db/sqlc/records.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.29.0
 // source: records.sql
 
-package db
+package sqlc
 
 import (
 	"context"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stsysd/sougen/api"
 	"github.com/stsysd/sougen/config"
+	"github.com/stsysd/sougen/db"
 	"github.com/stsysd/sougen/store"
 )
 
@@ -14,7 +15,7 @@ func main() {
 	cfg := config.NewConfig()
 
 	// SQLiteストアの初期化（マイグレーション関数を渡す）
-	sqliteStore, err := store.NewSQLiteStore(cfg.DataDir, runMigrations)
+	sqliteStore, err := store.NewSQLiteStore(cfg.DataDir, db.Migrate)
 	if err != nil {
 		log.Fatalf("Failed to initialize SQLite store: %v", err)
 	}

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -5,8 +5,8 @@ sql:
     schema: "db/schema/"
     gen:
       go:
-        package: "db"
-        out: "db"
+        package: "sqlc"
+        out: "db/sqlc"
         sql_package: "database/sql"
         emit_json_tags: true
         emit_db_tags: true


### PR DESCRIPTION
## Summary
- タグの順序保存機能を追加
- DBパッケージ構造をリファクタリング（sqlcコードを `db/sqlc/` に移動）
- JSON エラーレスポンスの一貫性を改善
- runn テストヘルパーを追加

## Changes
- **Tag Order Preservation**: タグの順序を保存する `order_index` カラムを追加
- **DB Package Reorganization**: `db/` パッケージを整理し、sqlc生成コードを `db/sqlc/` サブディレクトリに移動
- **Migration Improvements**: マイグレーション処理を `db/migration.go` に移動
- **Error Responses**: すべてのAPIエンドポイントで一貫したJSONエラーレスポンスを返すように改善
- **Test Infrastructure**: runn テストフレームワーク用のヘルパーコードを追加

## Test Plan
- [x] 既存のユニットテストが通ることを確認
- [x] タグの順序保存機能のテストを追加
- [x] マイグレーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)